### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-eleventy.yml
+++ b/.github/workflows/build-eleventy.yml
@@ -1,4 +1,6 @@
 name: Build Site with Eleventy
+permissions:
+  contents: write
 on:
   push:
     branches:
@@ -27,4 +29,3 @@ jobs:
          publish_dir: _site
          publish_branch: gh-pages
          github_token: ${{ secrets.GITHUB_TOKEN }}
-


### PR DESCRIPTION
Potential fix for [https://github.com/pachewise/pachewise.github.io/security/code-scanning/1](https://github.com/pachewise/pachewise.github.io/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps:
- The `contents: read` permission is needed for the `actions/checkout@v3` step to read the repository contents.
- The `contents: write` permission is required for the `peaceiris/actions-gh-pages@v3` step to deploy the built site to the `gh-pages` branch.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `build-deploy` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
